### PR TITLE
Define #DEFINE_SEMAPHORE if not defined

### DIFF
--- a/driver/dtrace_linux.h
+++ b/driver/dtrace_linux.h
@@ -65,6 +65,10 @@
 
 # define MUTEX_HELD dtrace_mutex_is_locked
 
+# if !defined(DEFINE_SEMAPHORE)
+#   define DEFINE_SEMAPHORE(_m)  DECLARE_MUTEX(_m)
+# endif
+
 #define PRIV_EFFECTIVE          (1 << 0)
 #define PRIV_DTRACE_KERNEL      (1 << 1)
 #define PRIV_DTRACE_PROC        (1 << 2)


### PR DESCRIPTION
At some point in Linux kernel history, `DECLARE_MUTEX` was renamed to `DEFINE_SEMAPHORE`. Older kernels like the stock kernel on Ubuntu 10.04.4 (Linux ubuntu 2.6.32-38-generic #83-Ubuntu SMP Wed Jan 4 11:13:04 UTC 2012 i686 GNU/Linux) don't have `DEFINE_SEMAPHORE` in their headers.

Fixes GH-11.
