### PR TITLE
Add a vagrant (http://vagrantup.com/) Ubuntu 11.10 vm that can be used for testing

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -1,0 +1,96 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant::Config.run do |config|
+  # All Vagrant configuration is done here. The most common configuration
+  # options are documented and commented below. For a complete reference,
+  # please see the online documentation at vagrantup.com.
+
+  # Every Vagrant virtual environment requires a box to build off of.
+  config.vm.box = "ubuntu-1110-server-amd64"
+
+  # The url from where the 'config.vm.box' box will be fetched if it
+  # doesn't already exist on the user's system.
+  config.vm.box_url = "http://timhuegdon.com/vagrant-boxes/ubuntu-11.10.box"
+
+  # Boot with a GUI so you can see the screen. (Default is headless)
+  # config.vm.boot_mode = :gui
+
+  # Assign this VM to a host-only network IP, allowing you to access it
+  # via the IP. Host-only networks can talk to the host machine as well as
+  # any other machines on the same network, but cannot be accessed (through this
+  # network interface) by any external networks.
+  config.vm.network :hostonly, "192.168.33.10"
+
+  # Assign this VM to a bridged network, allowing you to connect directly to a
+  # network using the host's network device. This makes the VM appear as another
+  # physical device on your network.
+  # config.vm.network :bridged
+
+  # Forward a port from the guest to the host, which allows for outside
+  # computers to access the VM, whereas host only networking does not.
+  config.vm.forward_port 80, 8081
+
+  # Share an additional folder to the guest VM. The first argument is
+  # an identifier, the second is the path on the guest to mount the
+  # folder, and the third is the path on the host to the actual folder.
+  # config.vm.share_folder "v-data", "/vagrant_data", "../data"
+
+  # Enable provisioning with Puppet stand alone.  Puppet manifests
+  # are contained in a directory path relative to this Vagrantfile.
+  # You will need to create the manifests directory and a manifest in
+  # the file ubuntu-1110-server-amd64.pp in the manifests_path directory.
+  #
+  # An example Puppet manifest to provision the message of the day:
+  #
+  # # group { "puppet":
+  # #   ensure => "present",
+  # # }
+  # #
+  # # File { owner => 0, group => 0, mode => 0644 }
+  # #
+  # # file { '/etc/motd':
+  # #   content => "Welcome to your Vagrant-built virtual machine!
+  # #               Managed by Puppet.\n"
+  # # }
+  #
+  config.vm.provision :puppet do |puppet|
+    puppet.manifests_path = "manifests"
+    puppet.manifest_file  = "ubuntu-1110-server-amd64.pp"
+  end
+
+  # Enable provisioning with chef solo, specifying a cookbooks path (relative
+  # to this Vagrantfile), and adding some recipes and/or roles.
+  #
+  # config.vm.provision :chef_solo do |chef|
+  #   chef.cookbooks_path = "cookbooks"
+  #   chef.add_recipe "mysql"
+  #   chef.add_role "web"
+  #
+  #   # You may also specify custom JSON attributes:
+  #   chef.json = { :mysql_password => "foo" }
+  # end
+
+  # Enable provisioning with chef server, specifying the chef server URL,
+  # and the path to the validation key (relative to this Vagrantfile).
+  #
+  # The Opscode Platform uses HTTPS. Substitute your organization for
+  # ORGNAME in the URL and validation key.
+  #
+  # If you have your own Chef Server, use the appropriate URL, which may be
+  # HTTP instead of HTTPS depending on your configuration. Also change the
+  # validation key to validation.pem.
+  #
+  # config.vm.provision :chef_client do |chef|
+  #   chef.chef_server_url = "https://api.opscode.com/organizations/ORGNAME"
+  #   chef.validation_key_path = "ORGNAME-validator.pem"
+  # end
+  #
+  # If you're using the Opscode platform, your validator client is
+  # ORGNAME-validator, replacing ORGNAME with your organization name.
+  #
+  # IF you have your own Chef Server, the default validation client name is
+  # chef-validator, unless you changed the configuration.
+  #
+  #   chef.validation_client_name = "ORGNAME-validator"
+end

--- a/vagrant/manifests/ubuntu-1110-server-amd64.pp
+++ b/vagrant/manifests/ubuntu-1110-server-amd64.pp
@@ -1,0 +1,50 @@
+group { "puppet":
+  ensure => "present",
+}
+
+File { owner => 0, group => 0, mode => 0644 }
+
+file { '/etc/motd':
+  content => "DTrace4Linux (https://github.com/dtrace4linux/linux) development environment virtual machine\ncreated by Marc Abramowitz <marc@marc-abramowitz.com>\nUbuntu 11.10 (\"Oneiric\")\n\n",
+}
+
+file { '/etc/apt/apt.conf.d/71AssumeYes':
+  content => "APT {\n  Get {\n    Assume-Yes \"true\";\n  };\n};\n",
+}
+
+exec { 'git_clone':
+  require   => Package['git-core'],
+  user      => 'vagrant',
+  cwd       => '/home/vagrant',
+  command   => '/usr/bin/git clone --quiet --branch get-deps-kernel-headers https://github.com/msabramo/linux.git dtrace4linux',
+  logoutput => "on_failure",
+}
+
+exec { 'get_deps':
+  require     => [ File['/etc/apt/apt.conf.d/71AssumeYes'], Exec['git_clone'], ],
+  user        => 'vagrant',
+  environment => 'DEBIAN_FRONTEND=noninteractive',
+  cwd         => '/home/vagrant/dtrace4linux',
+  command     => '/home/vagrant/dtrace4linux/tools/get-deps.pl',
+  timeout     => 600,
+  logoutput   => "on_failure",
+}
+
+exec { 'make':
+  require   => Exec['get_deps'],
+  cwd       => '/home/vagrant/dtrace4linux',
+  command   => '/usr/bin/make all && \
+                /usr/bin/make install && \
+                /usr/bin/make load && \
+                /sbin/lsmod | /bin/grep dtracedrv',
+  logoutput => "on_failure",
+}
+
+exec { 'test':
+  require => Exec['make'],
+  command => '/sbin/lsmod | /bin/grep dtracedrv; /usr/sbin/dtrace -l | /usr/bin/wc -l',
+  logoutput => true,
+}
+
+package { "git-core":                     ensure => present }
+package { "linux-headers-$kernelrelease": ensure => present }


### PR DESCRIPTION
To use this, you will need to install [VirtualBox](https://www.virtualbox.org/) and [Vagrant](http://vagrantup.com/).

Then do:

```
cd vagrant
vagrant up    # This part will take several minutes; feel free to grab a cup of coffee
vagrant ssh
```

If all goes well, you have a fresh new Ubuntu 11.10 vm. There is a clone of the [dtrace4linux repo](https://github.com/dtrace4linux/linux) in `/home/vagrant/dtrace4linux` and dtrace has already been installed and the kernel module loaded and is ready for playing around with.

Enjoy!