### PR TITLE
add libiberty-dev to tools/get-deps.pl

### DIFF
--- a/tools/get-deps.pl
+++ b/tools/get-deps.pl
@@ -47,7 +47,7 @@ install_dependencies()
 	sudo apt-get install "$@" libc6-dev 
 	sudo apt-get install "$@" openssh-server \
    		binutils-dev zlib1g-dev \
-   		elfutils libdwarf-dev libelf-dev libc-dev \
+   		elfutils libdwarf-dev libiberty-dev libelf-dev libc-dev \
 		zlib1g-dev \
 		linux-libc-dev \
 		linux-headers-$(uname -r) \


### PR DESCRIPTION
fix link issue on Ubuntu 14.04

``` bash
gcc -g -I. -I../../ -I../../libctf -I../../common -I../../uts/common -I../../linux -I/usr/include/libdwarf -o ../../build/ctfconvert ../../build/ctfconvert.obj/ctfconvert.o ../../build/ctfconvert.obj/alist.o ../../build/ctfconvert.obj/ctf.o ../../build/ctfconvert.obj/dwarf.o ../../build/ctfconvert.obj/hash.o ../../build/ctfconvert.obj/iidesc.o ../../build/ctfconvert.obj/input.o ../../build/ctfconvert.obj/list.o ../../build/ctfconvert.obj/memory.o ../../build/ctfconvert.obj/merge.o ../../build/ctfconvert.obj/output.o ../../build/ctfconvert.obj/st_bugs.o ../../build/ctfconvert.obj/st_parse.o ../../build/ctfconvert.obj/stabs.o ../../build/ctfconvert.obj/stack.o ../../build/ctfconvert.obj/strtab.o ../../build/ctfconvert.obj/symbol.o ../../build/ctfconvert.obj/tdata.o ../../build/ctfconvert.obj/traverse.o ../../build/ctfconvert.obj/util.o ../../build/libctf.a -ldwarf -liberty -lelf -lz
/usr/bin/ld: cannot find -liberty
collect2: error: ld returned 1 exit status
make[3]: *** [../../build/ctfconvert] Error 1
make[2]: *** [all] Error 2
make[1]: *** [do_cmds] Error 2
tools/bug.sh
make: *** [all] Error 1
```
