### PR TITLE
remove openssh-server from build dependencies

### DIFF
--- a/tools/get-deps.pl
+++ b/tools/get-deps.pl
@@ -45,7 +45,7 @@ install_dependencies()
 	sudo apt-get install "$@" flex bison make
 	sudo apt-get install "$@" libelf-dev
 	sudo apt-get install "$@" libc6-dev 
-	sudo apt-get install "$@" openssh-server \
+	sudo apt-get install "$@" \
    		binutils-dev zlib1g-dev \
    		elfutils libdwarf-dev libiberty-dev libelf-dev libc-dev \
 		zlib1g-dev \


### PR DESCRIPTION
I tried to build dtrace4linux on Ubuntu 14.04 LTS and found that openssh-server was installed and it
 started sshd server automatically.

dtrace4linux does not depend on openssh-server. We should remove it from get-deps.pl.
