### PR TITLE
Changes to support CentOS 7

### DIFF
--- a/driver/intr.c
+++ b/driver/intr.c
@@ -48,7 +48,7 @@
 #define store_idt(ptr) asm volatile("sidt %0":"=m" (*ptr))
 #endif
 
-#if !defined(store_gdt) && LINUX_VERSION_CODE >= KERNEL_VERSION(3, 11, 0)
+#if !defined(store_gdt) && LINUX_VERSION_CODE >= KERNEL_VERSION(3, 10, 0)
 	/***********************************************/
 	/*   Xen  removed  this - oh, so nice of you.  */
 	/*   Not! We want the GDT to debug dtrace, so  */

--- a/tools/get-deps-fedora.sh
+++ b/tools/get-deps-fedora.sh
@@ -14,6 +14,7 @@ yum install \
 	kernel-devel \
 	libdwarf \
 	libdwarf-devel \
+	libdwarf-static \
 	libgcc.i686 \
 	make \
 	perl \

--- a/tools/mkport.pl
+++ b/tools/mkport.pl
@@ -326,6 +326,7 @@ void	dwarf_begin();
 void main(int argc, char **argv)
 {
 	dwarf_begin();
+	dwarf_loclist();
 }
 EOF
 	$fh->close();


### PR DESCRIPTION
Three changes that seem to be required to get dtrace building on CentOS 7 for your review.

commit 8ee119b297aa0b30d99ac5817b99d342bf7edab5
Author: Logan O'Sullivan Bruns <logan@gedanken.org>
Date:   Sun Feb 8 03:44:13 2015 +0000

    Added libdwarf.a deps install for fedora/rhel/centos script

commit cffbd428ee71b11a6482d49da9b34706fd9fe1d9
Author: Logan O'Sullivan Bruns <logan@gedanken.org>
Date:   Sun Feb 8 03:41:51 2015 +0000

    Add dwarf_loclist to libdw vs. libdwarf check
    
    On CentOS 7 libdw does not include dwarf_loclist but libdwarf
    does. This changes adds checking for dwarf_loclist to the check to
    determine whether to use libdw instead of libdwarf.

commit d476c3a0dadb47c69f08dafce2b1a400cda49a58
Author: Logan O'Sullivan Bruns <logan@gedanken.org>
Date:   Sun Feb 8 03:38:34 2015 +0000

    Kernel 3.10 also appears to not have the store_gdt call either
    
    The current #ifdef says for 3.11 and above but 3.10 also does not
    appear to have the store_gdt call. This fixes a build issue on CentOS
    7 which includes the 3.10 kernel.
